### PR TITLE
Adapted to numpy >= 1.23.0

### DIFF
--- a/download_audio.py
+++ b/download_audio.py
@@ -30,7 +30,7 @@ episode_uri = args.episodes
 wav_dir = args.wavs
 
 # Load episode data
-table = np.loadtxt(episode_uri, dtype=str, delimiter=", ")
+table = np.genfromtxt(episode_uri, dtype=str, delimiter=", ")
 urls = table[:,2]
 n_items = len(urls)
 


### PR DESCRIPTION
`download_audio.py` currently doesn't work due to changes in numpy. Since numpy 1.23.0 the delimiter argument in `np.loadtext` can't be more than 1 character. Therefore using its more general version `np.genfromtxt` instead.