### PR TITLE
fix: resolve TypeError in download_audio.py

### DIFF
--- a/download_audio.py
+++ b/download_audio.py
@@ -30,7 +30,7 @@ episode_uri = args.episodes
 wav_dir = args.wavs
 
 # Load episode data
-table = np.loadtxt(episode_uri, dtype=str, delimiter=", ")
+table = np.genfromtxt(episode_uri, dtype=str, delimiter=", ")
 urls = table[:,2]
 n_items = len(urls)
 


### PR DESCRIPTION
### Description

I encountered a TypeError while using the np.loadtxt function in the library. The error message stated: "Text reading control character must be a single unicode character or None; but got: ','". This issue arises due to a change in how np.loadtxt handles control characters in the text.

### Solution
To resolve this issue, I replaced the usage of np.loadtxt with np.genfromtxt. Unlike np.loadtxt, np.genfromtxt can gracefully handle control characters in the text and prevents the TypeError.