### PR TITLE
replace np.loadtxt() with np.genfromtxt()

### DIFF
--- a/download_audio.py
+++ b/download_audio.py
@@ -30,7 +30,7 @@ episode_uri = args.episodes
 wav_dir = args.wavs
 
 # Load episode data
-table = np.loadtxt(episode_uri, dtype=str, delimiter=", ")
+table = np.genfromtxt(episode_uri, dtype=str, delimiter=", ")
 urls = table[:,2]
 n_items = len(urls)
 


### PR DESCRIPTION
In the script **download_audio.py**, `np.loadtxt()`has been replaced with its more general version `np.genfromtxt()` for the delimiter argument to work properly. Since numpy 1.23.0 upgrade the delimiter argument in np.loadtext can't be more than 1 character.